### PR TITLE
Gerrit: support all possible file statuses

### DIFF
--- a/formatchecker/gerrit.py
+++ b/formatchecker/gerrit.py
@@ -42,7 +42,11 @@ class Context:
         for filename in change_dict.keys():
             status = change_dict[filename].get("status", "M")
             file_get_url = urljoin(current_revision_url, "files/%s/content" % quote(filename, safe=''))
-            if status not in ["M", "D", "A"]:
+            if status in 'RC':
+                old_file_get_url = urljoin(current_revision_url, "files/%s/content" % quote(change_dict[filename]['old_path'], safe=''))
+            else:
+                old_file_get_url = file_get_url
+            if status not in ["M", "D", "A", "R", "C", "W"]:
                 raise RuntimeError("Unsupported file status change")
             # get the contents of the current patch version of the file
             if status != "D":
@@ -51,7 +55,7 @@ class Context:
             else:
                 patch_content = None
             if status != "A":
-                base_content = self._get(file_get_url, params={"parent": "1"})
+                base_content = self._get(old_file_get_url, params={"parent": "1"})
                 base_content = StringIO(base_content).readlines()
             else:
                 base_content = None

--- a/tests/data/test_gerrit_revision_files.json
+++ b/tests/data/test_gerrit_revision_files.json
@@ -16,5 +16,26 @@
 "lines_deleted": 51,
 "size_delta": -967,
 "size": 0
+},
+"src/file_renamed": {
+"status": "R",
+"old_path": "old/file_renamed",
+"lines_inserted": 2,
+"lines_deleted": 3,
+"size_delta": -30,
+"size": 314
+},
+"src/file_copied": {
+"status": "C",
+"old_path": "old/file_copied",
+"size_delta": 0,
+"size": 314
+},
+"src/file_rewritten": {
+"status": "W",
+"lines_inserted": 200,
+"lines_deleted": 300,
+"size_delta": -30,
+"size": 314
 }
 }

--- a/tests/test_gerrit.py
+++ b/tests/test_gerrit.py
@@ -41,13 +41,53 @@ def context_get_mock(self, url: str, params=None):
         else:
             raise RuntimeError("Invalid request for src/file_implicitly_modified content")
     elif url =="changes/test_get_change/revisions/current/files/src%2Ffile_deleted/content":
-        # This file is modified, so there is new and parent contents
+        # This file is deleted, so only support getting the old contents
         if params is None:
             raise RuntimeError("The src/file_deleted file is deleted, so the patched version should not be requested")
         elif params == {"parent": "1"}:
             return "file_deleted line 1\nfile_deleted line 2\n"
         else:
             raise RuntimeError("Invalid request for src/file_implicitly_modified content")
+    elif url =="changes/test_get_change/revisions/current/files/src%2Ffile_renamed/content":
+        # This is the new path of a renamed file, so only support getting the new contents
+        if params is None:
+            return "file_renamed line 1\nfile_renamed base line 2\n"
+        elif params == {"parent": "1"}:
+            raise RuntimeError("The src/file_renamed file is added, so the base version should not be requested")
+        else:
+            raise RuntimeError("Invalid request for src/file_renamed content")
+    elif url =="changes/test_get_change/revisions/current/files/old%2Ffile_renamed/content":
+        # This is the old path of a renamed file, so only support getting the old contents
+        if params is None:
+            raise RuntimeError("The old/file_renamed file was renamed, so the patched version should not be requested")
+        elif params == {"parent": "1"}:
+            return "file_renamed line 1\nfile_renamed patched line 2\n"
+        else:
+            raise RuntimeError("Invalid request for old/file_renamed content")
+    elif url =="changes/test_get_change/revisions/current/files/src%2Ffile_copied/content":
+        # This is the new path of a copied file, so only support getting the new contents
+        if params is None:
+            return "file_copied line 1\nfile_copied base line 2\n"
+        elif params == {"parent": "1"}:
+            raise RuntimeError("The src/file_copied file is added, so the base version should not be requested")
+        else:
+            raise RuntimeError("Invalid request for src/file_copied content")
+    elif url =="changes/test_get_change/revisions/current/files/old%2Ffile_copied/content":
+        # This is the old path of a copied file, so only support getting the old contents
+        if params is None:
+            raise RuntimeError("The old/file_copied file was copied in this change, so the patched version should not be requested")
+        elif params == {"parent": "1"}:
+            return "file_copied line 1\nfile_copied patched line 2\n"
+        else:
+            raise RuntimeError("Invalid request for old/file_copied content")
+    elif url =="changes/test_get_change/revisions/current/files/src%2Ffile_rewritten/content":
+        # This file is modified, so there is new and parent contents
+        if params is None:
+            return "file_rewritten line 1\n2Ffile_rewritten base line 2\n"
+        elif params == {"parent": "1"}:
+            return "file_rewritten line 1\n2Ffile_rewritten patched line 2\n"
+        else:
+            raise RuntimeError("Invalid request for src/file_rewritten content")
     raise ValueError("Input URL is not mocked: %s" % url)
 
 


### PR DESCRIPTION
Renamed, copied and rewritten, all treated as modifications.

Closes #5.